### PR TITLE
Optionally index static and data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Its information can be accessed via:
 | `{{ page.last_modified_at }}` | 2022-12-16 18:30:53 -0800 |
 | `{{ page.last_modified_at \| date: '%F' }}` | 2022-12-16 |
 | `{{ page.last_modified_at_formatted }}` | December 16, 2022 |
+| `{{ site.data.meta[data_file].last_modified_at_formatted }}` | December 16, 2022 |
 | `{% last_modified_at %}` | December 16, 2022 |
 | `{% last_modified_at %F %}` | 2022-12-16 |
+
 
 ## Installation
 
@@ -69,6 +71,8 @@ jekyll-last-commit:
   date_format: '%F'        # default: `%B %d, %Y`
   # if a commit is not found `File.mtime` is used
   should_fall_back_to_mtime: false # default: `true`
+  # information about data files is stored in a seperate site.data hash
+  data_files_key: 'meta'           # default: meta
 ```
 
 The use case for `should_fall_back_to_mtime` is so that rendering of a file that is not yet tracked by `git` looks correct (e.g. a new, uncommitted blog post).
@@ -76,6 +80,10 @@ The use case for `should_fall_back_to_mtime` is so that rendering of a file that
 ## Date Format Directives
 
 See [Time#strftime](https://ruby-doc.org/3.1.3/Time.html#method-i-strftime) documentation for available date format directives.
+
+### Data files
+
+Information about data files is stored in `site.data.meta`. The name of the key in `site.data` can be configured in `_config.yml`.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,12 @@ and run `bundle install`.
 All of the following are optional:
 ```yml
 jekyll-last-commit:
-  date_format: '%F'        # default: `%B %d, %Y`
+  date_format: '%F'                # default: `%B %d, %Y`
   # if a commit is not found `File.mtime` is used
   should_fall_back_to_mtime: false # default: `true`
+  # enable processing of data and static files
+  index_data_files: true           # default: false
+  index_static_files: true         # default: false
   # information about data files is stored in a seperate site.data hash
   data_files_key: 'meta'           # default: meta
 ```

--- a/lib/jekyll-last-commit/generator.rb
+++ b/lib/jekyll-last-commit/generator.rb
@@ -6,11 +6,28 @@ module JekyllLastCommit
     def generate(site)
       repo_man = JekyllLastCommit::RepoMan.new(site.source)
       repo_man.discover_repo()
+
+      data_file_extensions = ['.yml', '.yaml', '.json', '.tsv', '.csv']
+      data_files = []
+      site.data.keys.each do |data_file|
+        data_file_extensions.each do |data_file_extension|
+          data_file_name = data_file + data_file_extension
+          if File.file?('./_data/' + data_file_name)
+            data_files.append(data_file_name)
+            break
+          end
+        end
+      end     
+
       repo_man.discover_commits(site.documents.map {|d| d.relative_path })
       repo_man.discover_commits(site.pages.map {|p| p.relative_path })
+      repo_man.discover_commits(data_files.map {|df| './_data/' + df })
 
       date_format = site.config.dig('jekyll-last-commit', 'date_format')
       date_format ||= '%B %d, %Y'
+
+      data_file_key = site.config.dig('jekyll-last-commit', 'data_files_key')
+      data_file_key ||= 'meta'
 
       should_fall_back_to_mtime = site.config.dig('jekyll-last-commit', 'should_fall_back_to_mtime')
       should_fall_back_to_mtime = should_fall_back_to_mtime.nil? ? true : should_fall_back_to_mtime
@@ -32,10 +49,34 @@ module JekyllLastCommit
           end
         else
           raw_time = Time.at(commit["time"].to_i)
-
           document.data['last_commit'] = commit
           document.data['last_modified_at'] = raw_time
           document.data['last_modified_at_formatted'] = raw_time.strftime(date_format)
+        end
+      end
+
+      site.data[data_file_key] = {}
+      data_files.each do |data_file|
+        site.data[data_file_key][data_file] = {}
+
+        relative_path = './_data/' + data_file
+        commit = repo_man.find_commit(relative_path)
+
+        if commit.nil?
+          if should_fall_back_to_mtime
+            path_data_file = Jekyll.sanitized_path(site.source, relative_path)
+
+            if File.file?(data_file)
+              raw_time = Time.at(File.mtime(path_data_file).to_i)
+              site.data[data_file_key][data_file]['last_modified_at'] = raw_time
+              site.data[data_file_key][data_file]['last_modified_at_formatted'] = raw_time.strftime(date_format)
+            end
+          end
+        else
+          raw_time = Time.at(commit['time'].to_i)
+          site.data[data_file_key][data_file]['last_commit'] = commit
+          site.data[data_file_key][data_file]['last_modified_at'] = raw_time
+          site.data[data_file_key][data_file]['last_modified_at_formatted'] = raw_time.strftime(date_format)
         end
       end
 
@@ -55,13 +96,11 @@ module JekyllLastCommit
 
         else
           raw_time = Time.at(commit["time"].to_i)
-
           page.data['last_commit'] = commit
           page.data['last_modified_at'] = raw_time
           page.data['last_modified_at_formatted'] = raw_time.strftime(date_format)
         end
       end
     end
-
   end
 end

--- a/lib/jekyll-last-commit/generator.rb
+++ b/lib/jekyll-last-commit/generator.rb
@@ -2,103 +2,105 @@ require 'jekyll'
 
 module JekyllLastCommit
   class Generator < Jekyll::Generator
+    priority :highest
 
     def generate(site)
-      repo_man = JekyllLastCommit::RepoMan.new(site.source)
-      repo_man.discover_repo()
+      @site = site
 
-      data_file_extensions = ['.yml', '.yaml', '.json', '.tsv', '.csv']
-      data_files = []
-      site.data.keys.each do |data_file|
-        data_file_extensions.each do |data_file_extension|
-          data_file_name = data_file + data_file_extension
-          if File.file?('./_data/' + data_file_name)
-            data_files.append(data_file_name)
-            break
-          end
-        end
-      end     
+      @repo_man = JekyllLastCommit::RepoMan.new(site.source)
+      @repo_man.discover_repo()
 
-      repo_man.discover_commits(site.documents.map {|d| d.relative_path })
-      repo_man.discover_commits(site.pages.map {|p| p.relative_path })
-      repo_man.discover_commits(data_files.map {|df| './_data/' + df })
+      @date_format = site.config.dig('jekyll-last-commit', 'date_format')
+      @date_format ||= '%B %d, %Y'
 
-      date_format = site.config.dig('jekyll-last-commit', 'date_format')
-      date_format ||= '%B %d, %Y'
+      @should_fall_back_to_mtime = site.config.dig('jekyll-last-commit', 'should_fall_back_to_mtime')
+      @should_fall_back_to_mtime ||= true
 
-      data_files_key = site.config.dig('jekyll-last-commit', 'data_files_key')
-      data_files_key ||= 'meta'
+      @repo_man.discover_commits(site.documents.map {|d| d.relative_path })
+      populate_jekyll(site.documents)
 
-      should_fall_back_to_mtime = site.config.dig('jekyll-last-commit', 'should_fall_back_to_mtime')
-      should_fall_back_to_mtime = should_fall_back_to_mtime.nil? ? true : should_fall_back_to_mtime
+      @repo_man.discover_commits(site.pages.map {|p| p.relative_path })
+      populate_jekyll(site.pages)
 
-      site.documents.each do |document|
-        commit = repo_man.find_commit(document.relative_path)
-
-        if commit.nil?
-          if should_fall_back_to_mtime
-            path_document = Jekyll.sanitized_path(site.source, document.relative_path)
-
-            if File.file?(path_document)
-              raw_time = Time.at(File.mtime(path_document).to_i)
-
-              Jekyll.logger.warn "JekyllLastCommit: unable to find commit information for #{document.relative_path}. falling back to `mtime` for last_modified_at"
-              document.data['last_modified_at'] = raw_time
-              document.data['last_modified_at_formatted'] = raw_time.strftime(date_format)
-            end
-          end
-        else
-          raw_time = Time.at(commit["time"].to_i)
-          document.data['last_commit'] = commit
-          document.data['last_modified_at'] = raw_time
-          document.data['last_modified_at_formatted'] = raw_time.strftime(date_format)
-        end
+      index_static_files = site.config.dig('jekyll-last-commit', 'index_static_files')
+      index_static_files ||= false
+      if index_static_files
+        @repo_man.discover_commits(site.static_files.map {|sf| '.' + sf.relative_path })
+        populate_jekyll(site.static_files, '.')
       end
 
-      site.data[data_files_key] = {}
-      data_files.each do |data_file|
-        site.data[data_files_key][data_file] = {}
+      index_data_files = site.config.dig('jekyll-last-commit', 'index_data_files')
+      index_data_files ||= false
+      if index_data_files
+        data_file_extensions = ['.yml', '.yaml', '.json', '.tsv', '.csv']
+        data_files = []
+        site.data.keys.each do |data_file|
+          data_file_extensions.each do |data_file_extension|
+            data_file_name = data_file + data_file_extension
+            if File.file?('./_data/' + data_file_name)
+              data_files.append(data_file_name)
+              break
+            end
+          end
+        end
+      
+        data_files_key = site.config.dig('jekyll-last-commit', 'data_files_key')
+        data_files_key ||= 'meta'
 
-        relative_path = './_data/' + data_file
-        commit = repo_man.find_commit(relative_path)
+        @repo_man.discover_commits(data_files.map {|df| './_data/' + df })
+
+        site.data[data_files_key] = {}
+        populate_data(data_files, site.data[data_files_key], './_data/')
+      end
+    end
+
+    def populate_jekyll(files, prepend_path = '')
+      files.each do |file|
+        commit = @repo_man.find_commit(prepend_path + file.relative_path)
 
         if commit.nil?
-          if should_fall_back_to_mtime
-            path_data_file = Jekyll.sanitized_path(site.source, relative_path)
+          if @should_fall_back_to_mtime
+            path_file = Jekyll.sanitized_path(@site.source, prepend_path + file.relative_path)
 
-            if File.file?(data_file)
-              raw_time = Time.at(File.mtime(path_data_file).to_i)
-              site.data[data_files_key][data_file]['last_modified_at'] = raw_time
-              site.data[data_files_key][data_file]['last_modified_at_formatted'] = raw_time.strftime(date_format)
+            if File.file?(path_file)
+              raw_time = Time.at(File.mtime(path_file).to_i)
+              file.data['commit'] = prepend_path + file.relative_path
+              file.data['last_modified_at'] = raw_time
+              file.data['last_modified_at_formatted'] = raw_time.strftime(@date_format)
+            end
+          end
+
+        else
+          raw_time = Time.at(commit["time"].to_i)
+          file.data['last_commit'] = commit
+          file.data['last_modified_at'] = raw_time
+          file.data['last_modified_at_formatted'] = raw_time.strftime(@date_format)
+        end
+      end
+    end
+
+    def populate_data(source, output = {}, prepend_path = '')
+      source.each do |file|
+        output[file] ||= {}
+
+        relative_path = prepend_path + file
+        commit = @repo_man.find_commit(relative_path)
+
+        if commit.nil?
+          if @should_fall_back_to_mtime
+            path_file = Jekyll.sanitized_path(@site.source, relative_path)
+
+            if File.file?(file)
+              raw_time = Time.at(File.mtime(path_file).to_i)
+              output[file]['last_modified_at'] = raw_time
+              output[file]['last_modified_at_formatted'] = raw_time.strftime(@date_format)
             end
           end
         else
           raw_time = Time.at(commit['time'].to_i)
-          site.data[data_files_key][data_file]['last_commit'] = commit
-          site.data[data_files_key][data_file]['last_modified_at'] = raw_time
-          site.data[data_files_key][data_file]['last_modified_at_formatted'] = raw_time.strftime(date_format)
-        end
-      end
-
-      site.pages.each do |page|
-        commit = repo_man.find_commit(page.relative_path)
-
-        if commit.nil?
-          if should_fall_back_to_mtime
-            path_page = Jekyll.sanitized_path(site.source, page.relative_path)
-
-            if File.file?(path_page)
-              raw_time = Time.at(File.mtime(path_page).to_i)
-              page.data['last_modified_at'] = raw_time
-              page.data['last_modified_at_formatted'] = raw_time.strftime(date_format)
-            end
-          end
-
-        else
-          raw_time = Time.at(commit["time"].to_i)
-          page.data['last_commit'] = commit
-          page.data['last_modified_at'] = raw_time
-          page.data['last_modified_at_formatted'] = raw_time.strftime(date_format)
+          output[file]['last_commit'] = commit
+          output[file]['last_modified_at'] = raw_time
+          output[file]['last_modified_at_formatted'] = raw_time.strftime(@date_format)
         end
       end
     end

--- a/lib/jekyll-last-commit/generator.rb
+++ b/lib/jekyll-last-commit/generator.rb
@@ -26,8 +26,8 @@ module JekyllLastCommit
       date_format = site.config.dig('jekyll-last-commit', 'date_format')
       date_format ||= '%B %d, %Y'
 
-      data_file_key = site.config.dig('jekyll-last-commit', 'data_files_key')
-      data_file_key ||= 'meta'
+      data_files_key = site.config.dig('jekyll-last-commit', 'data_files_key')
+      data_files_key ||= 'meta'
 
       should_fall_back_to_mtime = site.config.dig('jekyll-last-commit', 'should_fall_back_to_mtime')
       should_fall_back_to_mtime = should_fall_back_to_mtime.nil? ? true : should_fall_back_to_mtime
@@ -55,9 +55,9 @@ module JekyllLastCommit
         end
       end
 
-      site.data[data_file_key] = {}
+      site.data[data_files_key] = {}
       data_files.each do |data_file|
-        site.data[data_file_key][data_file] = {}
+        site.data[data_files_key][data_file] = {}
 
         relative_path = './_data/' + data_file
         commit = repo_man.find_commit(relative_path)
@@ -68,15 +68,15 @@ module JekyllLastCommit
 
             if File.file?(data_file)
               raw_time = Time.at(File.mtime(path_data_file).to_i)
-              site.data[data_file_key][data_file]['last_modified_at'] = raw_time
-              site.data[data_file_key][data_file]['last_modified_at_formatted'] = raw_time.strftime(date_format)
+              site.data[data_files_key][data_file]['last_modified_at'] = raw_time
+              site.data[data_files_key][data_file]['last_modified_at_formatted'] = raw_time.strftime(date_format)
             end
           end
         else
           raw_time = Time.at(commit['time'].to_i)
-          site.data[data_file_key][data_file]['last_commit'] = commit
-          site.data[data_file_key][data_file]['last_modified_at'] = raw_time
-          site.data[data_file_key][data_file]['last_modified_at_formatted'] = raw_time.strftime(date_format)
+          site.data[data_files_key][data_file]['last_commit'] = commit
+          site.data[data_files_key][data_file]['last_modified_at'] = raw_time
+          site.data[data_files_key][data_file]['last_modified_at_formatted'] = raw_time.strftime(date_format)
         end
       end
 


### PR DESCRIPTION
This PR does three things:

* Refactors indexing into a seperate function
* Allows for indexing of data files
  * This is disabled by default, it can be enabled with the `index_data_files` setting in `_config.yml`
  * Information about data files is stored in a seperate `site.data` hash (called `meta` by default, but configurable in `_config.yml`) to avoid polluting/impacting any scripts that might process existing hashes
* Allows for indexing of static files
  * This is disabled by default, it can be enabled with the `index_static_files` setting in `_config.yml`

With some fairly simple Liquid (e.g., this [use here](https://github.com/acm-cui/website-community/blob/main/_includes/lastmod.html)), you can show the last edit to a page based on the page and its various sources.

I welcome any feedback/suggestions/review.